### PR TITLE
Upstream

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -271,6 +271,26 @@ aside {
   }
 }
 
+.draft-panels {
+
+  .draft-allegation .draft-text a {
+    color: $link;
+  }
+
+  .draft-allegation .draft-text h2 {
+    margin-bottom: $line-height / 3;
+    margin-top: 0;
+  }
+
+  ul,
+  ol {
+
+    li {
+      font-size: $base-font-size;
+    }
+  }
+}
+
 .back {
 
   .icon-angle-left {
@@ -466,6 +486,13 @@ body > header,
   background: #fff !important;
   justify-content: space-between;
 
+  @include breakpoint(small only) {
+
+    .menu {
+      margin-bottom: 0;
+    }
+  }
+
   .menu > li {
 
     a {
@@ -586,7 +613,10 @@ body > header,
 
 .subnavigation {
   background: $light;
-  padding: $line-height / 2 0;
+
+  @include breakpoint(medium) {
+    padding: $line-height / 2 0;
+  }
 }
 
 .subnavigation a {
@@ -639,9 +669,28 @@ body > header,
 
     &.opens-left > .is-dropdown-submenu {
       background: #fff;
+
+      @include breakpoint(small only) {
+        width: 100%;
+      }
     }
 
     &.is-dropdown-submenu-parent {
+
+      > a {
+
+        @include breakpoint(small only) {
+          display: inline;
+        }
+
+        &.is-active::after {
+          border: 0;
+          height: 4px;
+          left: 0;
+          top: unset;
+          width: calc(100% + 8px);
+        }
+      }
 
       > a::before {
         border: inset 6px;
@@ -651,14 +700,13 @@ body > header,
         content: "";
         display: block;
         position: absolute;
-        right: -7px;
-        top: 22px;
-      }
+        right: -8px;
+        top: 20px;
 
-      > a::after {
-        border: 0;
-        margin-top: -6px;
-        top: auto;
+        @include breakpoint(small only) {
+          right: -10px;
+          top: 8px;
+        }
       }
     }
 
@@ -673,12 +721,20 @@ body > header,
 
     a {
       font-size: 16px;
-      padding-left: $line-height / 4;
-      padding-right: $line-height / 4;
+      padding-right: $line-height / 2;
+
+      @include breakpoint(small only) {
+        line-height: $line-height * 2;
+      }
+
+      @include breakpoint(medium) {
+        padding-left: $line-height / 2;
+      }
     }
   }
 
   .dropdown .is-dropdown-submenu {
+    background: #fff;
     min-width: rem-calc(240);
     width: max-content;
 
@@ -724,6 +780,13 @@ body > header,
 
 .public > .wrapper > header::after {
   border-bottom: 0;
+}
+
+.locale .locale-form {
+
+  @include breakpoint(small-only) {
+    padding-left: $line-height / 4;
+  }
 }
 
 // 2. Homepage and custom pages
@@ -2242,6 +2305,33 @@ footer {
   span {
     font-style: normal;
     text-transform: uppercase;
+  }
+}
+
+.legislation-draft-versions-form .markdown-preview {
+  font-family: "Montserrat", sans-serif !important;
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Montserrat", sans-serif !important;
+    line-height: unset;
+  }
+
+  h1 {
+    font-size: rem-calc(44);
+  }
+
+  h2 {
+    font-size: rem-calc(34);
+  }
+
+  h3 {
+    font-size: rem-calc(24);
+    margin: 0;
   }
 }
 

--- a/app/components/budgets/investments/votes_component.html.erb
+++ b/app/components/budgets/investments/votes_component.html.erb
@@ -21,7 +21,7 @@
             <% end %>
           <% end %>
         </div>
-      <% else %>
+      <% elsif current_user %>
         <%= button_to t("budgets.investments.votes.support"), support_path,
             class: "button button-support expanded",
             title: t("budgets.investments.investment.support_title"),
@@ -30,6 +30,10 @@
             data:   ({ confirm: confirm_vote_message } if display_support_alert?),
             disabled: !current_user,
             "aria-label": support_aria_label %>
+      <% else %>
+        <div class="button button-support expanded">
+          <%= t("budgets.investments.votes.support") %>
+        </div>
       <% end %>
     <% end %>
   </div>

--- a/app/components/widget/feeds/budget_component.html.erb
+++ b/app/components/widget/feeds/budget_component.html.erb
@@ -25,7 +25,9 @@
       <h4><%= budget.current_phase.name %></h4>
     <% end %>
 
-    <p class="dates"><%= budget.start_date.to_date %> / <%= budget.end_date.to_date %></p>
+    <p class="dates">
+      <%= budget.current_phase.starts_at.to_date %> / <%= budget.current_phase.ends_at.to_date - 1.day %>
+    </p>
     <div class="description"><%= sanitize(strip_links(budget.description)) %></div>
     <p><%= t("welcome.feed.see_budget") %></p>
   <% end %>

--- a/app/models/legislation/draft_version.rb
+++ b/app/models/legislation/draft_version.rb
@@ -24,7 +24,7 @@ class Legislation::DraftVersion < ApplicationRecord
   def body_html
     renderer = Redcarpet::Render::HTML.new(with_toc_data: true)
 
-    Redcarpet::Markdown.new(renderer).render(body)
+    Redcarpet::Markdown.new(renderer, tables: true).render(body)
   end
 
   def toc_html

--- a/app/views/admin/debates/show.html.erb
+++ b/app/views/admin/debates/show.html.erb
@@ -18,7 +18,7 @@
     <%= l @debate.created_at.to_date %>
     <span class="bullet">&nbsp;&bull;&nbsp;</span>
     <span class="icon-comments"></span>&nbsp;
-    <%= link_to t("debates.show.comments", count: @debate.comments_count), "#comments" %>
+    <%= link_to t("debates.show.comments", count: @debate.comments_count), debate_path(@debate, anchor: "comments") %>
     <span class="bullet">&nbsp;&bull;&nbsp;</span>
     <span class="js-flag-actions">
       <%= render "shared/flag_actions", flaggable: @debate %>

--- a/app/views/admin/poll/polls/_form.html.erb
+++ b/app/views/admin/poll/polls/_form.html.erb
@@ -22,11 +22,11 @@
       </div>
 
       <div class="small-12 column">
-        <%= translations_form.text_area :summary, rows: 4 %>
+        <%= translations_form.text_area :summary, rows: 4, class: "html-area admin" %>
       </div>
 
       <div class="small-12 column">
-        <%= translations_form.text_area :description, rows: 8 %>
+        <%= translations_form.text_area :description, rows: 8, class: "html-area admin" %>
       </div>
     <% end %>
   </div>

--- a/app/views/layouts/_mailer_footer.html.erb
+++ b/app/views/layouts/_mailer_footer.html.erb
@@ -6,6 +6,12 @@
         <%= setting["org_name"] %></p>
 
         <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #222; font-size: 10px; margin-top: 12px;">
+          <%= sanitize(t("mailers.unsubscribe",
+                          link: link_to(t("mailers.unsubscribe_link"), account_url, target: "_blank")),
+                          attributes: %w[href target]) %>
+        </p>
+
+        <p style="font-family: 'Open Sans','Helvetica Neue',arial,sans-serif; margin: 0;padding: 0;line-height: 1.5em;color: #222; font-size: 10px; margin-top: 12px;">
         <%= t("mailers.no_reply") %></p>
       </td>
     </tr>

--- a/app/views/polls/_poll_header.html.erb
+++ b/app/views/polls/_poll_header.html.erb
@@ -9,7 +9,7 @@
 
       <h1><%= @poll.name %></h1>
 
-      <%= auto_link_already_sanitized_html simple_format(@poll.summary) %>
+      <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@poll.summary) %>
 
       <% if @poll.geozones.any? %>
         <ul class="margin-top tags">
@@ -22,12 +22,18 @@
       <% if @poll.description.present? %>
         <div id="poll_description_text" class="hide" data-toggler="hide">
           <h3><%= t("polls.show.more_info_title") %></h3>
-          <%= auto_link_already_sanitized_html simple_format(@poll.description) %>
+          <%= auto_link_already_sanitized_html AdminWYSIWYGSanitizer.new.sanitize(@poll.description) %>
         </div>
 
-        <a id="poll_description_more_info" data-toggle="poll_description_text" class="button primary">
+        <button type="button" id="read_more" class="button primary" data-toggler="hide"
+                data-toggle="poll_description_text read_more read_less">
           <%= t("polls.show.more_info_title") %>
-        </a>
+        </button>
+
+        <button type="button" id="read_less" class="button primary hide" data-toggler="hide"
+                data-toggle="poll_description_text read_more read_less">
+          <%= t("polls.show.less_info_title") %>
+        </button>
       <% end %>
 
       <%= render SDG::TagListComponent.new(@poll, linkable: false) %>

--- a/app/views/polls/show.html.erb
+++ b/app/views/polls/show.html.erb
@@ -65,18 +65,14 @@
                 <% if answer.description.length > 600 %>
                   <div class="read-more">
                     <button type="button" id="read_more_<%= answer.id %>"
-                            data-toggle="answer_description_<%= answer.id %>
-                                         read_more_<%= answer.id %>
-                                         read_less_<%= answer.id %>"
                             data-toggler="hide"
+                            data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
                             class="button primary">
                       <%= t("polls.show.read_more", answer: answer.title) %>
                     </button>
                     <button type="button" id="read_less_<%= answer.id %>"
-                            data-toggle="answer_description_<%= answer.id %>
-                                         read_more_<%= answer.id %>
-                                         read_less_<%= answer.id %>"
                             data-toggler="hide"
+                            data-toggle="answer_description_<%= answer.id %> read_more_<%= answer.id %> read_less_<%= answer.id %>"
                             class="hide button primary">
                       <%= t("polls.show.read_less", answer: answer.title) %>
                     </button>

--- a/config/deploy-secrets.yml.example
+++ b/config/deploy-secrets.yml.example
@@ -1,19 +1,17 @@
 staging:
   deploy_to: "/home/deploy/consul"
-  ssh_port: "21"
-  server: "staging.consul.es"
+  ssh_port: "22"
+  server: xxx.xxx.xxx.xxx
+  db_server: "localhost"
   user: "deploy"
-
-preproduction:
-  deploy_to: "/home/deploy/consul"
-  ssh_port: "2222"
-  server1: xxx.xxx.xxx.xxx
-  server2: xxx.xxx.xxx.xxx
-  user: "deploy"
+  server_name: "xxx.xxx.xxx.xxx"
+  full_app_name: "consul"
 
 production:
   deploy_to: "/home/deploy/consul"
   ssh_port: "22"
   server1: xxx.xxx.xxx.xxx
-  server2: xxx.xxx.xxx.xxx
+  db_server: "localhost"
   user: "deploy"
+  server_name: "xxx.xxx.xxx.xxx"
+  full_app_name: "consul"

--- a/config/locales/custom/nl/activerecord.yml
+++ b/config/locales/custom/nl/activerecord.yml
@@ -53,7 +53,7 @@ nl:
         email_on_comment: "Stuur mij een mail wanneer iemand reageert op mijn initiatieven of discussies"
         email_on_comment_reply: "Stuur mij een mail wanneer iemand op mijn reactie reageert"
         email_on_direct_message: "Ontvang emails over privéberichten"
-        newsletter: "Ontvang emails over website gerelateerde informatie"
+        newsletter: "Ontvang nieuwsbrieven van de website"
         public_activity: "Maak mijn activiteit openbaar"
         public_interests: "Maak de onderwerpen/labels die ik volg openbaar"
         recommended_debates: "Toon aanbevelingen voor discussie"

--- a/config/locales/custom/nl/general.yml
+++ b/config/locales/custom/nl/general.yml
@@ -50,7 +50,7 @@ nl:
         title: "Hulp bij discussies"
         description: "Start een discussie om je mening met anderen te delen over onderwerpen die jij belangrijk vindt."
         help_text_1: "Deel je mening over allerlei onderwerpen, kansen of knelpunten die jij belangrijk vindt."
-        help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je %{org}."
+        help_text_2: "Om een discussie te starten of om deel te nemen aan een discussie moet je je registreren op %{org}."
         help_text_link: "aanmelden"
       title: "Discussies"
       search_form:

--- a/config/locales/en/general.yml
+++ b/config/locales/en/general.yml
@@ -623,6 +623,7 @@ en:
       cant_answer_expired: "This poll has finished."
       cant_answer_wrong_geozone: "This question is not available on your geozone."
       more_info_title: "More information"
+      less_info_title: "Less information"
       more_info_options: "More information about the options"
       documents: Documents
       zoom_plus: Expand image

--- a/config/locales/en/mailers.yml
+++ b/config/locales/en/mailers.yml
@@ -2,6 +2,8 @@ en:
   mailers:
     title: "Open Government"
     no_reply: "This message was sent from an email address that does not accept replies."
+    unsubscribe: "If you want to stop receiving these emails, you can change your preferences on the \"%{link}\" page."
+    unsubscribe_link: "My Account"
     comment:
       hi: Hi
       new_comment_by: There is a new comment from <strong>%{commenter}</strong>

--- a/config/locales/es/general.yml
+++ b/config/locales/es/general.yml
@@ -626,6 +626,7 @@ es:
       cant_answer_expired: "Esta votación ha terminado."
       cant_answer_wrong_geozone: "Esta votación no está disponible en tu zona."
       more_info_title: "Más información"
+      less_info_title: "Menos información"
       more_info_options: "Más información sobre las opciones"
       documents: Documentos
       zoom_plus: Ampliar imagen

--- a/config/locales/es/mailers.yml
+++ b/config/locales/es/mailers.yml
@@ -2,6 +2,8 @@ es:
   mailers:
     title: "Gobierno abierto"
     no_reply: "Este mensaje se ha enviado desde una dirección de correo electrónico que no admite respuestas."
+    unsubscribe: "Si quieres dejar de recibir estos emails, puedes cambiar tus preferencias en \"%{link}\"."
+    unsubscribe_link: "Mi cuenta"
     comment:
       hi: Hola
       new_comment_by: Hay un nuevo comentario de <strong>%{commenter}</strong> en

--- a/config/locales/nl/general.yml
+++ b/config/locales/nl/general.yml
@@ -486,6 +486,7 @@ nl:
       cant_answer_expired: "Deze stemronde is voorbij."
       cant_answer_wrong_geozone: "Deze vraag wordt niet behandeld in uw regio"
       more_info_title: "Meer informatie"
+      less_info_title: "Minder informatie"
       documents: Documenten
       zoom_plus: Afbeelding vergroten
       read_more: "Lees meer over %{answer}"

--- a/config/locales/nl/mailers.yml
+++ b/config/locales/nl/mailers.yml
@@ -1,6 +1,8 @@
 nl:
   mailers:
     no_reply: "This message was sent from an email address that does not accept replies."
+    unsubscribe: "Wanneer je dit soort e-mails niet meer wilt ontvangen, verander dan de instellingen op de \"%{link}\" pagina."
+    unsubscribe_link: "Mijn Profiel"
     comment:
       hi: Hi
       new_comment_by: There is a new comment from <strong>%{commenter}</strong>

--- a/lib/admin_legislation_sanitizer.rb
+++ b/lib/admin_legislation_sanitizer.rb
@@ -1,6 +1,6 @@
 class AdminLegislationSanitizer < WYSIWYGSanitizer
   def allowed_tags
-    super + %w[img h1 h4 h5 h6]
+    super + %w[img h1 h4 h5 h6 hr blockquote code table thead tbody th tr td]
   end
 
   def allowed_attributes

--- a/spec/components/budgets/investments/votes_component_spec.rb
+++ b/spec/components/budgets/investments/votes_component_spec.rb
@@ -19,6 +19,7 @@ describe Budgets::Investments::VotesComponent do
       end
 
       it "disables the button to support the investment to unidentified users" do
+        skip "Add temporal custom button until version 1.5"
         render_inline component
 
         expect(page).to have_button count: 1, disabled: :all

--- a/spec/models/legislation/draft_version_spec.rb
+++ b/spec/models/legislation/draft_version_spec.rb
@@ -23,7 +23,11 @@ describe Legislation::DraftVersion do
     <<~BODY_MARKDOWN
       # Title 1
 
+      ---
+
       Some paragraph.
+
+      > Blockquote
 
       A list:
 
@@ -37,6 +41,13 @@ describe Legislation::DraftVersion do
       # Title 2
 
       Something about this.
+
+      `code`
+
+      | Syntax | Description |
+      | ----------- | ----------- |
+      | Header | Title |
+      | Paragraph | Text |
     BODY_MARKDOWN
   end
 
@@ -44,7 +55,13 @@ describe Legislation::DraftVersion do
     <<~BODY_HTML
       <h1 id="title-1">Title 1</h1>
 
+      <hr>
+
       <p>Some paragraph.</p>
+
+      <blockquote>
+      <p>Blockquote</p>
+      </blockquote>
 
       <p>A list:</p>
 
@@ -60,6 +77,24 @@ describe Legislation::DraftVersion do
       <h1 id="title-2">Title 2</h1>
 
       <p>Something about this.</p>
+
+      <p><code>code</code></p>
+
+      <table><thead>
+      <tr>
+      <th>Syntax</th>
+      <th>Description</th>
+      </tr>
+      </thead><tbody>
+      <tr>
+      <td>Header</td>
+      <td>Title</td>
+      </tr>
+      <tr>
+      <td>Paragraph</td>
+      <td>Text</td>
+      </tr>
+      </tbody></table>
     BODY_HTML
   end
 

--- a/spec/system/admin/debates_spec.rb
+++ b/spec/system/admin/debates_spec.rb
@@ -19,4 +19,14 @@ describe "Admin debates", :admin do
     expect(page).to have_content(debate.title)
     expect(page).to have_content(debate.description)
   end
+
+  scenario "Comments link" do
+    debate = create(:debate)
+    comment = create(:comment, commentable: debate)
+
+    visit admin_debate_path(debate)
+    click_link "1 comment"
+
+    expect(page).to have_content(comment.body)
+  end
 end

--- a/spec/system/admin/poll/polls_spec.rb
+++ b/spec/system/admin/poll/polls_spec.rb
@@ -63,8 +63,8 @@ describe "Admin polls", :admin do
     fill_in "Name", with: "Upcoming poll"
     fill_in "poll_starts_at", with: start_date
     fill_in "poll_ends_at", with: end_date
-    fill_in "Summary", with: "Upcoming poll's summary. This poll..."
-    fill_in "Description", with: "Upcomming poll's description. This poll..."
+    fill_in_ckeditor "Summary", with: "Upcoming poll's summary. This poll..."
+    fill_in_ckeditor "Description", with: "Upcomming poll's description. This poll..."
 
     expect(page).not_to have_css("#poll_results_enabled")
     expect(page).not_to have_css("#poll_stats_enabled")
@@ -547,8 +547,8 @@ describe "Admin polls", :admin do
       fill_in "Name", with: "Upcoming poll with SDG related content"
       fill_in "Start Date", with: 1.week.from_now
       fill_in "Closing Date", with: 2.weeks.from_now
-      fill_in "Summary", with: "Upcoming poll's summary. This poll..."
-      fill_in "Description", with: "Upcomming poll's description. This poll..."
+      fill_in_ckeditor "Summary", with: "Upcoming poll's summary. This poll..."
+      fill_in_ckeditor "Description", with: "Upcomming poll's description. This poll..."
 
       click_sdg_goal(17)
       click_button "Create poll"

--- a/spec/system/admin/system_emails_spec.rb
+++ b/spec/system/admin/system_emails_spec.rb
@@ -26,6 +26,20 @@ describe "System Emails" do
           end
         end
       end
+
+      scenario "have unsubscribe information" do
+        create(:comment, parent: create(:comment))
+        admin = create(:administrator)
+        create(:comment, :valuation, commentable: create(:budget_investment, administrator: admin))
+
+        system_emails.each do |email_id|
+          visit admin_system_email_view_path(email_id.to_s)
+
+          expect(page).to have_content "If you want to stop receiving these emails, you can change your "\
+                                       "preferences on the \"My Account\" page."
+          expect(page).to have_link "My account", href: account_path
+        end
+      end
     end
 
     context "System emails with preview" do

--- a/spec/system/admin/translatable_spec.rb
+++ b/spec/system/admin/translatable_spec.rb
@@ -248,14 +248,14 @@ describe "Admin edit translatable records", :admin do
       scenario "Updates the field to a blank value" do
         visit path
 
-        expect(page).to have_field "Summary", with: "Summary in English"
+        expect(page).to have_ckeditor "Summary", with: "Summary in English"
 
-        fill_in "Summary", with: ""
+        fill_in_ckeditor "Summary", with: " "
         click_button "Update poll"
 
         visit path
 
-        expect(page).to have_field "Summary", with: ""
+        expect(page).to have_ckeditor "Summary", with: ""
       end
     end
   end

--- a/spec/system/custom/welcome_page_spec.rb
+++ b/spec/system/custom/welcome_page_spec.rb
@@ -38,8 +38,8 @@ describe "Welcome page" do
         expect(page).to have_content budget.formatted_total_headings_price
         expect(page).to have_content budget.current_phase.name
         expect(page).to have_content "#{budget.current_enabled_phase_number}/#{budget.enabled_phases_amount}"
-        expect(page).to have_content "#{budget.start_date.to_date}"
-        expect(page).to have_content "#{budget.end_date.to_date}"
+        expect(page).to have_content budget.current_phase.starts_at.to_date.to_s
+        expect(page).to have_content (budget.current_phase.ends_at.to_date - 1.day).to_s
         expect(page).to have_content budget.description
         expect(page).to have_content "See this budget", count: 3
         expect(page).to have_link href: budget_path(budget)
@@ -47,16 +47,16 @@ describe "Welcome page" do
         expect(page).to have_content finished.formatted_total_headings_price
         expect(page).to have_content "COMPLETED"
         expect(page).to have_content "€", count: 1
-        expect(page).to have_content "#{finished.start_date.to_date}"
-        expect(page).to have_content "#{finished.end_date.to_date}"
+        expect(page).to have_content finished.current_phase.starts_at.to_date.to_s
+        expect(page).to have_content (finished.current_phase.ends_at.to_date - 1.day).to_s
         expect(page).to have_content finished.description
         expect(page).to have_link href: budget_path(finished)
         expect(page).not_to have_content draft.name
         expect(page).not_to have_content draft.description
         expect(page).not_to have_link href: budget_path(draft)
         expect(page).to have_content hide_money.name
-        expect(page).to have_content "#{hide_money.start_date.to_date}"
-        expect(page).to have_content "#{hide_money.end_date.to_date}"
+        expect(page).to have_content hide_money.current_phase.starts_at.to_date.to_s
+        expect(page).to have_content (hide_money.current_phase.ends_at.to_date - 1.day).to_s
         expect(page).to have_content hide_money.description
         expect(page).to have_link href: budget_path(hide_money)
       end

--- a/spec/system/polls/polls_spec.rb
+++ b/spec/system/polls/polls_spec.rb
@@ -231,8 +231,11 @@ describe "Polls" do
       expect(page).to have_content("Question 1 #{proposal_question.title}", normalize_ws: true)
       expect(page).to have_content("Question 2 #{normal_question.title}", normalize_ws: true)
 
-      find("#poll_description_more_info").click
+      find("#read_more").click
       expect(page).to have_content(poll.description)
+
+      find("#read_less").click
+      expect(page).not_to have_content(poll.description)
     end
 
     scenario "Do not show question number in polls with one question" do
@@ -361,20 +364,32 @@ describe "Polls" do
 
     scenario "Read more button appears only in long answer descriptions" do
       question = create(:poll_question, poll: poll)
-      create(:poll_question_answer, title: "Long answer", question: question,
-             description: Faker::Lorem.characters(number: 700))
+      answer_long = create(:poll_question_answer, title: "Long answer", question: question,
+                           description: Faker::Lorem.characters(number: 700))
       create(:poll_question_answer, title: "Short answer", question: question,
              description: Faker::Lorem.characters(number: 100))
 
       visit poll_path(poll)
 
+      expect(page).to have_content "Long answer"
       expect(page).to have_content "Short answer"
-      expect(page).to have_content "Short answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description.short"
 
       within "#poll_more_info_answers" do
         expect(page).to have_content "Read more about Long answer"
         expect(page).not_to have_content "Read more about Short answer"
       end
+
+      find("#read_more_#{answer_long.id}").click
+
+      expect(page).to have_content "Read less about Long answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description"
+      expect(page).not_to have_css "#answer_description_#{answer_long.id}.answer-description.short"
+
+      find("#read_less_#{answer_long.id}").click
+
+      expect(page).to have_content "Read more about Long answer"
+      expect(page).to have_css "#answer_description_#{answer_long.id}.answer-description.short"
     end
 
     scenario "Show orbit bullets only when there is more than one image" do


### PR DESCRIPTION
## Objectives

- Bump rails from 5.2.6 to 5.2.7.
- Bump Rails from 5.2.7 to 5.2.7.1.
- Move banner styles to their own stylesheet.
- Fix banner link on Chromium 101.
- Allow send newsletters with images.
- Fix margins on header content.
- Update deploy-secrets.yml.example.
- Monitor CONSUL with monit.
- Improve subnavigation styles on mobile screens.
- Fix deployment error after adding monit.
- Fix link to comments on admin view for debates.
- Add new tags on legislation markdown.
- Fix subnavigation dropdown menu styles.
- Fix homepage feeds participation layout.
- Update custom nl text.
- Add unsubscribe info on system emails.
- Fix debate show votes alignment.
- Fix draft comments button alignment.
- Update custom texts.
- Show progress bar for all budgets.
- Replace budget feeds date phase.
- Show participation not allowed message on mobile.
- Add wysiwyg to poll description and summary.
- Add read less button on poll header.
- Fix data-toggle on poll answer description.
- Add background color to mobile menu.